### PR TITLE
フォント読み込みの修正

### DIFF
--- a/src/style/_base.sass
+++ b/src/style/_base.sass
@@ -1,9 +1,8 @@
-@import 'http://fonts.googleapis.com/earlyaccess/notosansjapanese.css'
+@import 'loadNotoFont'
 
 body
   font-family: 'Noto Sans Japanese', 游ゴシック体, 'Yu Gothic', YuGothic, 'ヒラギノ角ゴシック Pro', 'Hiragino Kaku Gothic Pro', メイリオ, Meiryo, Osaka, 'ＭＳ Ｐゴシック', 'MS PGothic', sans-serif !important
   font-weight: 300
-  // font-display: swap
 
 $green: #009544
 

--- a/src/style/_loadNotoFont.sass
+++ b/src/style/_loadNotoFont.sass
@@ -1,0 +1,48 @@
+@font-face
+  font-family: 'Noto Sans Japanese'
+  font-style: normal
+  font-weight: 100
+  src: url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Thin.woff2) format("woff2"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Thin.woff) format("woff"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Thin.otf) format("opentype")
+  font-display: swap
+
+@font-face
+  font-family: 'Noto Sans Japanese'
+  font-style: normal
+  font-weight: 200
+  src: url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Light.woff2) format("woff2"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Light.woff) format("woff"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Light.otf) format("opentype")
+  font-display: swap
+
+@font-face
+  font-family: 'Noto Sans Japanese'
+  font-style: normal
+  font-weight: 300
+  src: url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-DemiLight.woff2) format("woff2"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-DemiLight.woff) format("woff"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-DemiLight.otf) format("opentype")
+  font-display: swap
+
+@font-face
+  font-family: 'Noto Sans Japanese'
+  font-style: normal
+  font-weight: 400
+  src: url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Regular.woff2) format("woff2"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Regular.woff) format("woff"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Regular.otf) format("opentype")
+  font-display: swap
+
+@font-face
+  font-family: 'Noto Sans Japanese'
+  font-style: normal
+  font-weight: 500
+  src: url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Medium.woff2) format("woff2"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Medium.woff) format("woff"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Medium.otf) format("opentype")
+  font-display: swap
+
+@font-face
+  font-family: 'Noto Sans Japanese'
+  font-style: normal
+  font-weight: 700
+  src: url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Bold.woff2) format("woff2"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Bold.woff) format("woff"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Bold.otf) format("opentype")
+  font-display: swap
+
+@font-face
+  font-family: 'Noto Sans Japanese'
+  font-style: normal
+  font-weight: 900
+  src: url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Black.woff2) format("woff2"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Black.woff) format("woff"), url(//fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Black.otf) format("opentype")
+  font-display: swap


### PR DESCRIPTION
# 目的
```sass
font-display: swap
```
の適用

## するとどうなる
- ロードするファイルが１つ減る
  - 使うfont-weightをしっかり決めればよりロード容量を減らせる
- フォントのロードが完了するまでは別のフォントで表示を補う
  - 文字表示がとりあえず早くなる

## 参考
- [[CSS]Web制作者が知っておきたい、Webフォントを快適に表示するCSSの新しいプロパティ「font-display」 | コリス](https://coliss.com/articles/build-websites/operation/css/about-font-display.html)

# 実際に行ったこと
- [x] Google fontの読み込みコードをローカルに置く
- [x] font-display: swapの追記
