### PR TITLE
白地に対するフォントカラーの検討

### DIFF
--- a/src/style/_base.sass
+++ b/src/style/_base.sass
@@ -1,7 +1,7 @@
 @import 'http://fonts.googleapis.com/earlyaccess/notosansjapanese.css'
 
 body
-  color: #555
+  color: #373C38
   font-family: 'Noto Sans Japanese', 游ゴシック体, 'Yu Gothic', YuGothic, 'ヒラギノ角ゴシック Pro', 'Hiragino Kaku Gothic Pro', メイリオ, Meiryo, Osaka, 'ＭＳ Ｐゴシック', 'MS PGothic', sans-serif !important
   font-weight: 300
   // font-display: swap


### PR DESCRIPTION
# 目的
白地に真黒は目に刺さるので、変更案を模索。

- #373C38（現状）
  - 若干G濃いめで
- #555
  - 店で言ってたやつ。ちょっと薄すぎ？
- #787878
  - 初期の某施設。文章は薄いけどトップビューは悪くないかも