### PR TITLE
Gridレイアウト部分CSSリファクタリング

### DIFF
--- a/src/style/main.sass
+++ b/src/style/main.sass
@@ -180,15 +180,15 @@
         grid-template-columns: 100px 1fr
         grid-gap: 0 10px
         img
-          grid-row: 1 / 1
+          grid-row: 1 / 3
           grid-column: 1 / 2
         h3
           grid-row: 1 / 2
-          grid-column: 2 / 2
+          grid-column: 2 / 3
           margin-top: 0px
         p
-          grid-row: 2 / 2
-          grid-column: 2 / 2
+          grid-row: 2 / 3
+          grid-column: 2 / 3
           margin-top: 0px
 
 #price


### PR DESCRIPTION
**responsiveブランチへのPRです**

# 目的
```sass
display: grid
```
に関するリファクタリング
# 実際に行ったこと
||1||2||3|
|:-:|:-:|:-:|:-:|:-:|:-:|
|1|+|-|+|-|+|
||/|image|/|h3|/|
|2|+|︙|+|-|+|
||/|image|/|p|/|
|3|+|-|+|-|+|

構成は2*2なので、それに合わせて最低限までリファクタリングする

## 参考
[CSS Grid Layout を極める！（基礎編） / ラインの番号で指定する](https://qiita.com/kura07/items/e633b35e33e43240d363#%E3%82%B9%E3%83%86%E3%83%83%E3%83%97%EF%BC%93-css-%E3%81%A7%E3%82%A2%E3%82%A4%E3%83%86%E3%83%A0%E3%81%AE%E9%85%8D%E7%BD%AE%E3%82%92%E6%8C%87%E5%AE%9A%E3%81%99%E3%82%8B)