### PR TITLE
Update sass for braking changes

### DIFF
--- a/src/style/main.sass
+++ b/src/style/main.sass
@@ -1,3 +1,5 @@
+@use "sass:math"
+
 @import './reset'
 
 @import '@fullcalendar/timegrid/main.css'
@@ -204,7 +206,7 @@
         display: block
         overflow-y: hidden
         height: calc(((100vw - 100px - #{$listGridGap} * 2) / 3) * (9 / 16))
-        max-height: (($listMaxWidth - $listGridGap * 2) / 3 ) * (9 / 16)
+        max-height: math.div(($listMaxWidth - $listGridGap * 2), 3 ) * math.div(9, 16)
         position: relative
         background-color: darken($green, 10%)
         +max-SP
@@ -384,10 +386,10 @@
         margin: 40px 20px auto
         .list
           justify-content: space-between
-          margin: 20px (-$margin-mf / 2)
+          margin: 20px math.div(-$margin-mf, 2)
         .item
-          width: (700px - $margin-mf)/3
-          margin: 0 $margin-mf/2 auto
+          width: math.div((700px - $margin-mf), 3)
+          margin: 0 math.div($margin-mf, 2) auto
           +max-SP
             width: 300px
         .info


### PR DESCRIPTION

# 目的
https://sass-lang.com/documentation/breaking-changes/slash-div/ に対する対応

# 実際に行ったこと
- [x] `/` を `math.div()`に置き換える
